### PR TITLE
move is_active additional to separated migration

### DIFF
--- a/db/migrate/1_create_videos_videos.rb
+++ b/db/migrate/1_create_videos_videos.rb
@@ -10,7 +10,6 @@ class CreateVideosVideos < ActiveRecord::Migration
       t.integer  "poster_id"
       t.boolean  "use_shared"
       t.text     "embed_tag"
-      t.boolean  'is_active', default: false
     end
   end
 

--- a/db/migrate/5_add_is_active_to_refinery_videos.rb
+++ b/db/migrate/5_add_is_active_to_refinery_videos.rb
@@ -1,0 +1,7 @@
+class AddIsActiveToRefineryVideos < ActiveRecord::Migration
+
+  def change
+    add_column :refinery_videos, :is_active, :boolean, default: false
+  end
+
+end


### PR DESCRIPTION
If you use refinerycms-videojs earlier, table refinery_videos already exist and you need to create own migration. This PR fix it.
